### PR TITLE
adding core css file and loading

### DIFF
--- a/frontend/modules/base/css/core.css
+++ b/frontend/modules/base/css/core.css
@@ -1,0 +1,32 @@
+/* Sticky footer styles
+-------------------------------------------------- */
+html {
+  position: relative;
+  min-height: 100%;
+}
+
+body {
+  /* Margin bottom by footer height */
+  margin-bottom: 60px;
+}
+
+.navbar {
+  /* Margin bottom by footer height */
+  margin-bottom: 0px;
+}
+
+#content {
+  margin-bottom: 20px;
+}
+
+/* Custom page CSS
+-------------------------------------------------- */
+/* Not required for template or sticky footer method. */
+
+.container .text-muted {
+  margin: 20px 0;
+}
+
+code {
+  font-size: 80%;
+}

--- a/frontend/modules/base/css/footer.css
+++ b/frontend/modules/base/css/footer.css
@@ -1,24 +1,3 @@
-/* Sticky footer styles
--------------------------------------------------- */
-html {
-  position: relative;
-  min-height: 100%;
-}
-
-body {
-  /* Margin bottom by footer height */
-  margin-bottom: 60px;
-}
-
-.navbar {
-  /* Margin bottom by footer height */
-  margin-bottom: 0px;
-}
-
-#content {
-  margin-bottom: 20px;
-}
-
 .footer {
   position: absolute;
   bottom: 0;
@@ -28,20 +7,7 @@ body {
   background-color: #f5f5f5;
 }
 
-
-/* Custom page CSS
--------------------------------------------------- */
-/* Not required for template or sticky footer method. */
-
-.container .text-muted {
-  margin: 20px 0;
-}
-
 .footer > .container {
   padding-right: 15px;
   padding-left: 15px;
-}
-
-code {
-  font-size: 80%;
 }

--- a/frontend/modules/index.js
+++ b/frontend/modules/index.js
@@ -23,6 +23,7 @@ import AuthStore from './account/stores/AuthStore'
 
 // Load in the base CSS
 require("../node_modules/bootstrap-sass/assets/stylesheets/_bootstrap.scss");
+require("./base/css/core.css");
 
 const requireAuth = (nextState, replace) => {
   if (!AuthStore.isAuthenticated()) {


### PR DESCRIPTION
Seems like moving to loading bootstrap on our own might have cause some weird css ordering changes. I noticed this when on the homepage when the carousel had an extra 20px white space on the top.

To solve this I'm moving all the non-footer css to its own file. Then loading that right after we load bootstrap.