### PR TITLE
Adding back json request in the api calls

### DIFF
--- a/frontend/modules/common/config.js
+++ b/frontend/modules/common/config.js
@@ -7,16 +7,15 @@ var apiUrl = apiHost + '/api/v1';
 
 export var serverURLs = {
   auth_token: apiUrl + '/accounts/obtain-auth-token/',
-  browse: apiUrl + '/recipe/recipes/?fields=id,title,pub_date,rating,photo_thumbnail,info',
+  browse: apiUrl + '/recipe/recipes/?fields=id,title,pub_date,rating,photo_thumbnail,info&format=json',
   mini_browse: apiUrl + '/recipe/mini-browse/?format=json',
-  //create: apiUrl + '/recipe/recipes/',
-  cuisine: apiUrl + '/recipe_groups/cuisine/',
-  course: apiUrl + '/recipe_groups/course/',
+  cuisine: apiUrl + '/recipe_groups/cuisine/?format=json',
+  course: apiUrl + '/recipe_groups/course/?format=json',
   tag: apiUrl + '/recipe_groups/tag/?format=json',
   ingredient: apiUrl + '/ingredient/ingredient/?format=json',
   direction: apiUrl + '/recipe/direction/?format=json',
   news: apiUrl + '/news/entry/?format=json',
-  recipe: apiUrl + '/recipe/recipes/',
+  recipe: apiUrl + '/recipe/recipes/?format=json',
 };
 
 export var measurements = [

--- a/frontend/modules/common/config.js
+++ b/frontend/modules/common/config.js
@@ -15,7 +15,7 @@ export var serverURLs = {
   ingredient: apiUrl + '/ingredient/ingredient/?format=json',
   direction: apiUrl + '/recipe/direction/?format=json',
   news: apiUrl + '/news/entry/?format=json',
-  recipe: apiUrl + '/recipe/recipes/?format=json',
+  recipe: apiUrl + '/recipe/recipes/',
 };
 
 export var measurements = [


### PR DESCRIPTION
I was testing some styles on chrome/firefox/safari when I noticed that the data for the browse page and list page wasn't loading in firefox. Looks like `res.body` doesn't populate if the request type isn't specify application/json.

Edit: Doing some more digging and found the default content type that firefox appends is text/html. So the default response is the whole HTML page that Django Rest Framework produces.